### PR TITLE
Adjust mininum render dimensions to 6x6 tiles to account for pixel shifted objects.

### DIFF
--- a/MapDiffBot/Core/PayloadProcessor.cs
+++ b/MapDiffBot/Core/PayloadProcessor.cs
@@ -438,7 +438,7 @@ namespace MapDiffBot.Core
 							{
 								var xdiam = region.MaxX - region.MinX;
 								var ydiam = region.MaxY - region.MinY;
-								const int minDiffDimensions = 5 - 1;
+								const int minDiffDimensions = 6 - 1;
 								if (xdiam < minDiffDimensions || ydiam < minDiffDimensions)
 								{
 									//need to expand


### PR DESCRIPTION
Fixes #102 