### PR TITLE
Blacklisting

### DIFF
--- a/MapDiffBot/Configuration/GitHubConfiguration.cs
+++ b/MapDiffBot/Configuration/GitHubConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace MapDiffBot.Configuration
+﻿using System.Collections.Generic;
+
+namespace MapDiffBot.Configuration
 {
 	/// <summary>
 	/// GitHub configuration settings
@@ -39,5 +41,10 @@
 		/// The client secret for the Oauth application
 		/// </summary>
 		public string OauthSecret { get; set; }
+
+		/// <summary>
+		/// A list of blacklisted repos
+		/// </summary>
+		public List<long> BlacklistedRepos { get; set; }
 	}
 }

--- a/MapDiffBot/Configuration/GitHubConfiguration.cs
+++ b/MapDiffBot/Configuration/GitHubConfiguration.cs
@@ -45,6 +45,6 @@ namespace MapDiffBot.Configuration
 		/// <summary>
 		/// A list of blacklisted repos
 		/// </summary>
-		public List<long> BlacklistedRepos { get; set; }
+		public List<long> BlacklistedRepos { get; }
 	}
 }

--- a/MapDiffBot/Core/PayloadProcessor.cs
+++ b/MapDiffBot/Core/PayloadProcessor.cs
@@ -147,6 +147,17 @@ namespace MapDiffBot.Core
 
 				var checkRunId = await gitHubManager.CreateCheckRun(repositoryId, ncr, cancellationToken).ConfigureAwait(false);
 
+				if (gitHubConfiguration.BlacklistedRepos.Contains(repositoryId)) {
+					logger.LogWarning("Pull request is from a blacklisted repo. Aborting.");
+					await gitHubManager.UpdateCheckRun(repositoryId, checkRunId, new CheckRunUpdate {
+						CompletedAt = DateTimeOffset.Now,
+						Status = CheckStatus.Completed,
+						Conclusion = CheckConclusion.Neutral,
+						Output = new CheckRunOutput(stringLocalizer["Blacklisted From Service"], stringLocalizer["This repository is blacklisted from using MapDiffBot. Please contact support in coderbus."], null, null, null)
+					}, cancellationToken).ConfigureAwait(false);
+					return;
+				}
+
 				Task HandleCancel() => gitHubManager.UpdateCheckRun(repositoryId, checkRunId, new CheckRunUpdate
 				{
 					CompletedAt = DateTimeOffset.Now,

--- a/MapDiffBot/appsettings.json
+++ b/MapDiffBot/appsettings.json
@@ -39,6 +39,7 @@
         "OauthClientID": "Fake",
         "OauthSecret": "Fake",
         "PemPath": "path/to/private/key/pem",
-        "AppID": 0
+        "AppID": 0,
+        "BlacklistedRepos": []
     }
 }


### PR DESCRIPTION
Allows repo blacklisting. Why? Because travis test repos that have 50+ map edits bog down the entire system. 

Shows this error message
![image](https://user-images.githubusercontent.com/25063394/89881070-ec1ed680-dbbc-11ea-9fda-63bdd85466dc.png)

Note how the check stays as neutral instead of a failure to avoid false failures on PRs
![image](https://user-images.githubusercontent.com/25063394/89881127-f93bc580-dbbc-11ea-8b76-ca0fc8807712.png)
