### PR TITLE
Adds ability to ignore specific PRs

### DIFF
--- a/MapDiffBot/Core/PayloadProcessor.cs
+++ b/MapDiffBot/Core/PayloadProcessor.cs
@@ -155,6 +155,17 @@ namespace MapDiffBot.Core
 					return;
 				}
 
+				if (pullRequest.Title.Contains("[MDB IGNORE]", StringComparison.InvariantCultureIgnoreCase)) {
+					logger.LogWarning("Pull request has [MDB IGNORE] in title. Aborting.");
+					await gitHubManager.UpdateCheckRun(repositoryId, checkRunId, new CheckRunUpdate {
+						CompletedAt = DateTimeOffset.Now,
+						Status = CheckStatus.Completed,
+						Conclusion = CheckConclusion.Neutral,
+						Output = new NewCheckRunOutput(stringLocalizer["PR Ignored"], stringLocalizer["This PR has `[MDB IGNORE]` in the title. Aborting."])
+					}, cancellationToken).ConfigureAwait(false);
+					return;
+				}
+
 				Task HandleCancel() => gitHubManager.UpdateCheckRun(repositoryId, checkRunId, new CheckRunUpdate
 				{
 					CompletedAt = DateTimeOffset.Now,


### PR DESCRIPTION
Same PR as the IDB one, but `[MDB IGNORE]` instead.



I did not test this, because I cannot be bothered to. It built locally and the IDB one works in prod. 